### PR TITLE
Replace mksrcinfo with makepkg --printsrcinfo

### DIFF
--- a/pre-commit.hook
+++ b/pre-commit.hook
@@ -18,7 +18,7 @@ unset GIT_DIR
 for path in $(git diff --name-only --cached --diff-filter=AM); do
     if [[ "${path}" =~ .*/PKGBUILD$ ]]; then
         echo -e "\e[01;32m *** Generating and adding .SRCINFO for ${path%/PKGBUILD} ***\e[00m"
-        (cd ${path%PKGBUILD} && makepkg --verifysource -f && mksrcinfo) || exit 1
+        (cd ${path%PKGBUILD} && makepkg --verifysource -f && makepkg --printsrcinfo > .SRCINFO) || exit 1
         git add ${path%PKGBUILD}/.SRCINFO
     fi
 done


### PR DESCRIPTION
This remove the dependency on pkgbuild-introspection.

I’m opening this for discussion, since I’ve been using this for a while but not being sure of the downsides (which I suspect exists since it’s not being used here). The run time is bit more elevated (0.3s instead of 0.07s on my machine), but imperceptible IMHO.

Also, if they are downsides, could them be fixed in `makepkg --printsrcinfo`?

I’ve tried to look at both implementation source code, but they are a bit obscure to me.
