### PR TITLE
Need to create version.h before building

### DIFF
--- a/lastpass-cli-git/PKGBUILD
+++ b/lastpass-cli-git/PKGBUILD
@@ -25,6 +25,8 @@ pkgver() {
 }
 
 build() {
+    cd "${srcdir}/${pkgname%-git}"
+    ./LASTPASS-VERSION-GEN
     mkdir -p "${srcdir}/${pkgname%-git}/build"
     cd "${srcdir}/${pkgname%-git}/build"
     cmake -G "Unix Makefiles" \


### PR DESCRIPTION
The `version.h` file needs to be created with `LASTPASS-VERSION-GEN` before starting the build. It's there since https://github.com/lastpass/lastpass-cli/commit/fe69be72079270f7c14dc5394f4d2f7b0c6e51c8#diff-fbbbbe0aa30003a580f128e4bfb4d942