### PR TITLE
OpenZFS 2.0.0

### DIFF
--- a/zfs-dkms/.SRCINFO
+++ b/zfs-dkms/.SRCINFO
@@ -1,28 +1,29 @@
 pkgbase = zfs-dkms
 	pkgdesc = Kernel modules for the Zettabyte File System.
-	pkgver = 0.8.5
+	pkgver = 2.0.0
 	pkgrel = 1
 	url = https://zfsonlinux.org/
 	arch = any
 	license = CDDL
-	provides = ZFS-MODULE=0.8.5
-	provides = SPL-MODULE=0.8.5
+	provides = ZFS-MODULE=2.0.0
+	provides = SPL-MODULE=2.0.0
 	provides = spl-dkms
 	provides = zfs
 	conflicts = spl-dkms
 	replaces = spl-dkms
-	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-0.8.5/zfs-0.8.5.tar.gz
-	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-0.8.5/zfs-0.8.5.tar.gz.asc
+	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-2.0.0/zfs-2.0.0.tar.gz
+	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-2.0.0/zfs-2.0.0.tar.gz.asc
 	source = 0001-only-build-the-module-in-dkms.conf.patch
 	validpgpkeys = 4F3BA9AB6D1F8D683DC2DFB56AD860EED4598027
 	validpgpkeys = C33DF142657ED1F7C328A2960AB9E991C6AF658B
-	sha256sums = dbb41d6b9c606a34ac93f4c19069fd6806ceeacb558f834f8a70755dadb7cd3d
+	sha256sums = 3403bf8e993f3c9d772f768142117df47bdbbb8e9bbf85a29c0e166f577f9311
 	sha256sums = SKIP
-	sha256sums = 780e590383fb00389c5e02ac15709b7a476d9e07d3c4935ed9eb67c951a88409
-	b2sums = 8376f360369c4657ff1fc040fb2bba780bbd5d6a98d149d2fa4ba39478588e213dbf6db218c7bd970839f015a69ae00ac951b90afc1c26b34aadf666b2976cab
+	sha256sums = c87fcf018784583b0d1d867d77f9bd5ebacc077d68dd0745ac06e7a83e94e6da
+	b2sums = 2961b97aa6736af9b4a2bc968d1488f49ec0c0fd7bb22b6bc015047239279efd2d48f8d7c593f9b467ac9d40f99d67363ab551bdfaf1dd71335c37c48c759875
 	b2sums = SKIP
-	b2sums = 1fdae935043d979b9241f07f8baa25a9a0367c24c31c84a59dfe8d6b468a523d8f49b68da3c7fd3194db6638f9d7bef046fc5e2669ce25d73c65009c16bf6c50
+	b2sums = e97f88650bb00f62d798ee02e3d1f454cb460c0f75d3c7c99da1adcf6776fb5e6452ee6fd3ef0b3d9e5cdae86f878a414814955408a09814d3d4f2478e1d73b8
 
 pkgname = zfs-dkms
-	depends = zfs-utils=0.8.5
+	depends = zfs-utils=2.0.0
 	depends = dkms
+

--- a/zfs-dkms/0001-only-build-the-module-in-dkms.conf.patch
+++ b/zfs-dkms/0001-only-build-the-module-in-dkms.conf.patch
@@ -33,10 +33,10 @@ index 88c289383..5a859a0e0 100755
 -  )
 +  --with-linux=\${kernel_source_dir}
    --with-linux-obj=\${kernel_source_dir}
-   --with-spl=\${source_tree}/spl-\${PACKAGE_VERSION}
-   --with-spl-obj=\${dkms_tree}/spl/\${PACKAGE_VERSION}/\${kernelver}/\${arch}
-@@ -78,7 +63,7 @@ POST_BUILD="scripts/dkms.postbuild
- BUILD_DEPENDS[0]="spl"
+   \$(
+     [[ -n \"\${ICP_ROOT}\" ]] && \\
+@@ -74,7 +59,7 @@ POST_BUILD="scripts/dkms.postbuild
+ "
  AUTOINSTALL="yes"
  REMAKE_INITRD="no"
 -MAKE[0]="make"

--- a/zfs-dkms/PKGBUILD
+++ b/zfs-dkms/PKGBUILD
@@ -4,7 +4,7 @@
 # All my PKGBUILDs are managed at https://github.com/eli-schwartz/pkgbuilds
 
 pkgname=zfs-dkms
-pkgver=0.8.5
+pkgver=2.0.0
 pkgrel=1
 pkgdesc="Kernel modules for the Zettabyte File System."
 arch=('any')
@@ -17,12 +17,12 @@ provides+=('zfs')
 replaces=('spl-dkms')
 source=("https://github.com/zfsonlinux/zfs/releases/download/zfs-${pkgver}/zfs-${pkgver}.tar.gz"{,.asc}
         "0001-only-build-the-module-in-dkms.conf.patch")
-sha256sums=('dbb41d6b9c606a34ac93f4c19069fd6806ceeacb558f834f8a70755dadb7cd3d'
+sha256sums=('3403bf8e993f3c9d772f768142117df47bdbbb8e9bbf85a29c0e166f577f9311'
             'SKIP'
-            '780e590383fb00389c5e02ac15709b7a476d9e07d3c4935ed9eb67c951a88409')
-b2sums=('8376f360369c4657ff1fc040fb2bba780bbd5d6a98d149d2fa4ba39478588e213dbf6db218c7bd970839f015a69ae00ac951b90afc1c26b34aadf666b2976cab'
+            'c87fcf018784583b0d1d867d77f9bd5ebacc077d68dd0745ac06e7a83e94e6da')
+b2sums=('2961b97aa6736af9b4a2bc968d1488f49ec0c0fd7bb22b6bc015047239279efd2d48f8d7c593f9b467ac9d40f99d67363ab551bdfaf1dd71335c37c48c759875'
         'SKIP'
-        '1fdae935043d979b9241f07f8baa25a9a0367c24c31c84a59dfe8d6b468a523d8f49b68da3c7fd3194db6638f9d7bef046fc5e2669ce25d73c65009c16bf6c50')
+        'e97f88650bb00f62d798ee02e3d1f454cb460c0f75d3c7c99da1adcf6776fb5e6452ee6fd3ef0b3d9e5cdae86f878a414814955408a09814d3d4f2478e1d73b8')
 validpgpkeys=('4F3BA9AB6D1F8D683DC2DFB56AD860EED4598027'  # Tony Hutter (GPG key for signing ZFS releases) <hutter2@llnl.gov>
               'C33DF142657ED1F7C328A2960AB9E991C6AF658B') # Brian Behlendorf <behlendorf1@llnl.gov>
 

--- a/zfs-utils/.SRCINFO
+++ b/zfs-utils/.SRCINFO
@@ -1,25 +1,26 @@
 pkgbase = zfs-utils
 	pkgdesc = Userspace utilities for the Zettabyte File System.
-	pkgver = 0.8.5
+	pkgver = 2.0.0
 	pkgrel = 1
 	url = https://zfsonlinux.org/
 	arch = i686
 	arch = x86_64
 	license = CDDL
 	optdepends = python: for arcstat/arc_summary/dbufstat
-	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-0.8.5/zfs-0.8.5.tar.gz
-	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-0.8.5/zfs-0.8.5.tar.gz.asc
+	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-2.0.0/zfs-2.0.0.tar.gz
+	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-2.0.0/zfs-2.0.0.tar.gz.asc
 	source = zfs.initcpio.install
 	source = zfs.initcpio.hook
 	validpgpkeys = 4F3BA9AB6D1F8D683DC2DFB56AD860EED4598027
 	validpgpkeys = C33DF142657ED1F7C328A2960AB9E991C6AF658B
-	sha256sums = dbb41d6b9c606a34ac93f4c19069fd6806ceeacb558f834f8a70755dadb7cd3d
+	sha256sums = 3403bf8e993f3c9d772f768142117df47bdbbb8e9bbf85a29c0e166f577f9311
 	sha256sums = SKIP
 	sha256sums = da1cdc045d144d2109ec7b5d97c53a69823759d8ecff410e47c3a66b69e6518d
 	sha256sums = 9c20256093997f7cfa9e7eb5d85d4a712d528a6ff19ef35b83ad03fb1ceae3bc
-	b2sums = 8376f360369c4657ff1fc040fb2bba780bbd5d6a98d149d2fa4ba39478588e213dbf6db218c7bd970839f015a69ae00ac951b90afc1c26b34aadf666b2976cab
+	b2sums = 2961b97aa6736af9b4a2bc968d1488f49ec0c0fd7bb22b6bc015047239279efd2d48f8d7c593f9b467ac9d40f99d67363ab551bdfaf1dd71335c37c48c759875
 	b2sums = SKIP
 	b2sums = 570e995bba07ea0fb424dff191180b8017b6469501964dc0b70fd51e338a4dad260f87cc313489866cbfd1583e4aac2522cf7309c067cc5314eb83c37fe14ff3
 	b2sums = e14366cbf680e3337d3d478fe759a09be224c963cc5207bee991805312afc49a49e6691f11e5b8bbe8dde60e8d855bd96e7f4f48f24a4c6d4a8c1bab7fc2bba0
 
 pkgname = zfs-utils
+

--- a/zfs-utils/PKGBUILD
+++ b/zfs-utils/PKGBUILD
@@ -4,7 +4,7 @@
 # All my PKGBUILDs are managed at https://github.com/eli-schwartz/pkgbuilds
 
 pkgname=zfs-utils
-pkgver=0.8.5
+pkgver=2.0.0
 pkgrel=1
 pkgdesc="Userspace utilities for the Zettabyte File System."
 arch=("i686" "x86_64")
@@ -14,11 +14,11 @@ optdepends=('python: for arcstat/arc_summary/dbufstat')
 source=("https://github.com/zfsonlinux/zfs/releases/download/zfs-${pkgver}/zfs-${pkgver}.tar.gz"{,.asc}
         "zfs.initcpio.install"
         "zfs.initcpio.hook")
-sha256sums=('dbb41d6b9c606a34ac93f4c19069fd6806ceeacb558f834f8a70755dadb7cd3d'
+sha256sums=('3403bf8e993f3c9d772f768142117df47bdbbb8e9bbf85a29c0e166f577f9311'
             'SKIP'
             'da1cdc045d144d2109ec7b5d97c53a69823759d8ecff410e47c3a66b69e6518d'
             '9c20256093997f7cfa9e7eb5d85d4a712d528a6ff19ef35b83ad03fb1ceae3bc')
-b2sums=('8376f360369c4657ff1fc040fb2bba780bbd5d6a98d149d2fa4ba39478588e213dbf6db218c7bd970839f015a69ae00ac951b90afc1c26b34aadf666b2976cab'
+b2sums=('2961b97aa6736af9b4a2bc968d1488f49ec0c0fd7bb22b6bc015047239279efd2d48f8d7c593f9b467ac9d40f99d67363ab551bdfaf1dd71335c37c48c759875'
         'SKIP'
         '570e995bba07ea0fb424dff191180b8017b6469501964dc0b70fd51e338a4dad260f87cc313489866cbfd1583e4aac2522cf7309c067cc5314eb83c37fe14ff3'
         'e14366cbf680e3337d3d478fe759a09be224c963cc5207bee991805312afc49a49e6691f11e5b8bbe8dde60e8d855bd96e7f4f48f24a4c6d4a8c1bab7fc2bba0')


### PR DESCRIPTION
This updates zfs-dkms and zfs-utils for OpenZFS 2.0.0: https://github.com/openzfs/zfs/releases/tag/zfs-2.0.0

zfs-utils is a straightforward bump, zfs-dkms includes a refresh for `0001-only-build-the-module-in-dkms.conf.patch` so it applies cleanly.