### PR TITLE
[zfs-dkms] Add 5.13 compat patches

### DIFF
--- a/zfs-dkms/.SRCINFO
+++ b/zfs-dkms/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = zfs-dkms
 	pkgdesc = Kernel modules for the Zettabyte File System.
 	pkgver = 2.0.4
-	pkgrel = 2
+	pkgrel = 3
 	url = https://zfsonlinux.org/
 	arch = any
 	license = CDDL
@@ -13,22 +13,26 @@ pkgbase = zfs-dkms
 	replaces = spl-dkms
 	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-2.0.4/zfs-2.0.4.tar.gz
 	source = https://github.com/zfsonlinux/zfs/releases/download/zfs-2.0.4/zfs-2.0.4.tar.gz.asc
-	source = https://github.com/openzfs/zfs/pull/12009/commits/938a7a375b2c18fef621fb30d71bec0c19e94142.patch
-	source = https://github.com/openzfs/zfs/pull/12009/commits/8122746cc52741e2d010aa0ad8e0f15ab24bbf28.patch
+	source = https://github.com/openzfs/zfs/commit/f315d9a3ff3cc0b81c99dd9be5878a55d2e98d8e.patch
+	source = https://github.com/openzfs/zfs/commit/77352db228c07ce8ba50478b9029820ca69c6c1b.patch
+	source = https://github.com/openzfs/zfs/commit/48c7b0e444591ca5e0199e266e79ecff53e81ee6.patch
 	source = 0001-only-build-the-module-in-dkms.conf.patch
 	validpgpkeys = 4F3BA9AB6D1F8D683DC2DFB56AD860EED4598027
 	validpgpkeys = C33DF142657ED1F7C328A2960AB9E991C6AF658B
 	sha256sums = 7d1344c5433b91823f02c2e40b33d181fa6faf286bea5591f4b1965f23d45f6c
 	sha256sums = SKIP
-	sha256sums = 6650bcaf8c1ebe23a0f749feeaf316b75148a76549129deba5f65d4555b2b874
-	sha256sums = 61595dd8b1e3fa4c7ca61a67a6960135ee11710d80f9fe6bec7071acece84028
+	sha256sums = f91835f187f5210fd855ee929b8f893771874a456db2bee685f71c833c696db8
+	sha256sums = d44e6e7b6a6aa5dc4422127f23524f315463fb9c042a519817b4f9cba5c483d1
+	sha256sums = b1ca71fa483c11b49cc8d59c1d5a465b6eae8bd66e71eed4e52aac1e8d50a7d7
 	sha256sums = 780e590383fb00389c5e02ac15709b7a476d9e07d3c4935ed9eb67c951a88409
 	b2sums = 7e4780092c0a87d5d187cd5734ddc736574db80b500f155287640ef2230e09335cc9b6b26ec1b7d8ab1b7942673ea49a3007a81da372a6d2ac36f3908913045c
 	b2sums = SKIP
-	b2sums = 195fe600d859ac6832891b5c938b2d55e22cfbbf8da56772e884d436ace9b48c8571015d1440884efc1e531294e8ef95ce45d69a22a93ef62e1016e497856a3f
-	b2sums = d6e67e037375dc99a3caacec257901c5678b08e42fa2158ce8d8bd0b93d47b9bd69b95042bac7a58bf987c155107fe80c93b57c0cd38e4065dbac24ac409cc54
+	b2sums = 49724351c5a8e6ffa66762d5aac84ad89a3d04022d086d9f37ccd616b3e8e95852197b5333bdeeeab54fc51516d8254d0138a4422cc66214bb602e5ed72bbabf
+	b2sums = cfe0d17448f25ec649ca7cf0bb7ee4f2685d09b2fa693b411f31a4035e113627c8be73514b39f2460646b9a556a133afcbfc803675d93d1fd5d93d64d8b4e7b2
+	b2sums = a5dcba48e91d4b6f797b2d660a2b2f4774daa7564718288a83aea0fb7f21fd7c53531922dce4f0d749bf0b39d2fcfdfaf7e1f91ce0c9fe9b4f12e3446a6110ce
 	b2sums = 1fdae935043d979b9241f07f8baa25a9a0367c24c31c84a59dfe8d6b468a523d8f49b68da3c7fd3194db6638f9d7bef046fc5e2669ce25d73c65009c16bf6c50
 
 pkgname = zfs-dkms
 	depends = zfs-utils=2.0.4
 	depends = dkms
+

--- a/zfs-dkms/PKGBUILD
+++ b/zfs-dkms/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=zfs-dkms
 pkgver=2.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Kernel modules for the Zettabyte File System."
 arch=('any')
 url="https://zfsonlinux.org/"
@@ -16,18 +16,21 @@ provides=("ZFS-MODULE=${pkgver}" "SPL-MODULE=${pkgver}" 'spl-dkms')
 provides+=('zfs')
 replaces=('spl-dkms')
 source=("https://github.com/zfsonlinux/zfs/releases/download/zfs-${pkgver}/zfs-${pkgver}.tar.gz"{,.asc}
-        "https://github.com/openzfs/zfs/pull/12009/commits/938a7a375b2c18fef621fb30d71bec0c19e94142.patch"
-        "https://github.com/openzfs/zfs/pull/12009/commits/8122746cc52741e2d010aa0ad8e0f15ab24bbf28.patch"
+        "https://github.com/openzfs/zfs/commit/f315d9a3ff3cc0b81c99dd9be5878a55d2e98d8e.patch"
+        "https://github.com/openzfs/zfs/commit/77352db228c07ce8ba50478b9029820ca69c6c1b.patch"
+        "https://github.com/openzfs/zfs/commit/48c7b0e444591ca5e0199e266e79ecff53e81ee6.patch"
         "0001-only-build-the-module-in-dkms.conf.patch")
 sha256sums=('7d1344c5433b91823f02c2e40b33d181fa6faf286bea5591f4b1965f23d45f6c'
             'SKIP'
-            '6650bcaf8c1ebe23a0f749feeaf316b75148a76549129deba5f65d4555b2b874'
-            '61595dd8b1e3fa4c7ca61a67a6960135ee11710d80f9fe6bec7071acece84028'
+            'f91835f187f5210fd855ee929b8f893771874a456db2bee685f71c833c696db8'
+            'd44e6e7b6a6aa5dc4422127f23524f315463fb9c042a519817b4f9cba5c483d1'
+            'b1ca71fa483c11b49cc8d59c1d5a465b6eae8bd66e71eed4e52aac1e8d50a7d7'
             '780e590383fb00389c5e02ac15709b7a476d9e07d3c4935ed9eb67c951a88409')
 b2sums=('7e4780092c0a87d5d187cd5734ddc736574db80b500f155287640ef2230e09335cc9b6b26ec1b7d8ab1b7942673ea49a3007a81da372a6d2ac36f3908913045c'
         'SKIP'
-        '195fe600d859ac6832891b5c938b2d55e22cfbbf8da56772e884d436ace9b48c8571015d1440884efc1e531294e8ef95ce45d69a22a93ef62e1016e497856a3f'
-        'd6e67e037375dc99a3caacec257901c5678b08e42fa2158ce8d8bd0b93d47b9bd69b95042bac7a58bf987c155107fe80c93b57c0cd38e4065dbac24ac409cc54'
+        '49724351c5a8e6ffa66762d5aac84ad89a3d04022d086d9f37ccd616b3e8e95852197b5333bdeeeab54fc51516d8254d0138a4422cc66214bb602e5ed72bbabf'
+        'cfe0d17448f25ec649ca7cf0bb7ee4f2685d09b2fa693b411f31a4035e113627c8be73514b39f2460646b9a556a133afcbfc803675d93d1fd5d93d64d8b4e7b2'
+        'a5dcba48e91d4b6f797b2d660a2b2f4774daa7564718288a83aea0fb7f21fd7c53531922dce4f0d749bf0b39d2fcfdfaf7e1f91ce0c9fe9b4f12e3446a6110ce'
         '1fdae935043d979b9241f07f8baa25a9a0367c24c31c84a59dfe8d6b468a523d8f49b68da3c7fd3194db6638f9d7bef046fc5e2669ce25d73c65009c16bf6c50')
 validpgpkeys=('4F3BA9AB6D1F8D683DC2DFB56AD860EED4598027'  # Tony Hutter (GPG key for signing ZFS releases) <hutter2@llnl.gov>
               'C33DF142657ED1F7C328A2960AB9E991C6AF658B') # Brian Behlendorf <behlendorf1@llnl.gov>
@@ -37,9 +40,12 @@ prepare() {
 
     patch -p1 -i ../0001-only-build-the-module-in-dkms.conf.patch
 
-    # Kernel 5.12 compat, https://github.com/openzfs/zfs/pull/12009
-    patch -p1 -i ../938a7a375b2c18fef621fb30d71bec0c19e94142.patch
-    patch -p1 -i ../8122746cc52741e2d010aa0ad8e0f15ab24bbf28.patch
+    # Kernel 5.12 compat
+    patch -p1 -i ../f315d9a3ff3cc0b81c99dd9be5878a55d2e98d8e.patch
+    patch -p1 -i ../77352db228c07ce8ba50478b9029820ca69c6c1b.patch
+
+    # Kernel 5.13 compat
+    patch -p1 -i ../48c7b0e444591ca5e0199e266e79ecff53e81ee6.patch
 
     # remove unneeded sections from module build
     sed -ri "/AC_CONFIG_FILES/,/]\)/{


### PR DESCRIPTION
This PR merges a compat patch https://github.com/openzfs/zfs/commit/48c7b0e444591ca5e0199e266e79ecff53e81ee6 for kernel 5.13.

It also switches the 5.12 compat patches to use the commits merged into zfs-2.0.5-staging rather than from the upstream PR 12009.