### PR TITLE
zfs-utils{,-git}: Install /usr/share/zfs/compatibility.d.

### DIFF
--- a/zfs-utils-git/.SRCINFO
+++ b/zfs-utils-git/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = zfs-utils-git
 	pkgdesc = Userspace utilities for the Zettabyte File System.
 	pkgver = 2.0.0rc1.r38.gcd80273909
-	pkgrel = 1
+	pkgrel = 2
 	epoch = 2
 	url = https://zfsonlinux.org/
 	arch = i686

--- a/zfs-utils-git/PKGBUILD
+++ b/zfs-utils-git/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=zfs-utils-git
 pkgver=2.0.0rc1.r38.gcd80273909
-pkgrel=1
+pkgrel=2
 epoch=2
 pkgdesc="Userspace utilities for the Zettabyte File System."
 arch=("i686" "x86_64")
@@ -69,7 +69,8 @@ package() {
     #rm -r "${pkgdir}"/usr/lib/dracut
     rm -r "${pkgdir}"/usr/lib/modules-load.d
     rm -r "${pkgdir}"/usr/share/initramfs-tools
-    rm -r "${pkgdir}"/usr/share/zfs
+    rm -r "${pkgdir}"/usr/share/zfs/*.sh
+    rm -r "${pkgdir}"/usr/share/zfs/{runfiles,test-runner,zfs-tests}
 
     install -D -m644 "${srcdir}"/zfs.initcpio.hook "${pkgdir}"/usr/lib/initcpio/hooks/zfs
     install -D -m644 "${srcdir}"/zfs.initcpio.install "${pkgdir}"/usr/lib/initcpio/install/zfs

--- a/zfs-utils/.SRCINFO
+++ b/zfs-utils/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = zfs-utils
 	pkgdesc = Userspace utilities for the Zettabyte File System.
 	pkgver = 2.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://zfsonlinux.org/
 	arch = i686
 	arch = x86_64

--- a/zfs-utils/PKGBUILD
+++ b/zfs-utils/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=zfs-utils
 pkgver=2.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Userspace utilities for the Zettabyte File System."
 arch=("i686" "x86_64")
 url="https://zfsonlinux.org/"
@@ -61,7 +61,8 @@ package() {
     #rm -r "${pkgdir}"/usr/lib/dracut
     rm -r "${pkgdir}"/usr/lib/modules-load.d
     rm -r "${pkgdir}"/usr/share/initramfs-tools
-    rm -r "${pkgdir}"/usr/share/zfs
+    rm -r "${pkgdir}"/usr/share/zfs/*.sh
+    rm -r "${pkgdir}"/usr/share/zfs/{runfiles,test-runner,zfs-tests}
 
     install -D -m644 "${srcdir}"/zfs.initcpio.hook "${pkgdir}"/usr/lib/initcpio/hooks/zfs
     install -D -m644 "${srcdir}"/zfs.initcpio.install "${pkgdir}"/usr/lib/initcpio/install/zfs


### PR DESCRIPTION
These have been added in 2.1.0 in https://github.com/openzfs/zfs/pull/11468
and refined in https://github.com/openzfs/zfs/pull/11861.