### PR TITLE
Pacman static

### DIFF
--- a/pacman-static/PKGBUILD
+++ b/pacman-static/PKGBUILD
@@ -18,7 +18,7 @@ _libassuanver=2.5.5
 _gpgmever=1.15.1
 pkgrel=1
 pkgdesc="Statically-compiled pacman (to fix or install systems without libc)"
-arch=('i686' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
+arch=('i486' 'i686' 'pentium4' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
 url="https://www.archlinux.org/pacman/"
 license=('GPL')
 depends=('pacman')
@@ -124,7 +124,7 @@ export CXX=musl-gcc
 
 # https://www.openwall.com/lists/musl/2014/11/05/3
 # fstack-protector and musl do not get along but only on i686
-if [[ $CARCH = i686 ]]; then
+if [[ $CARCH = i686 || $CARCH = pentium4 || $CARCH = i486 ]]; then
     # silly build systems have configure checks or buildtime programs that don't CFLAGS but do do CC
     export CC="musl-gcc -fno-stack-protector"
     export CXX="musl-gcc -fno-stack-protector"
@@ -147,9 +147,17 @@ build() {
             openssltarget='linux-x86_64'
             optflags='enable-ec_nistp_64_gcc_128'
             ;;
-        i686)
+        pentium4)
             openssltarget='linux-elf'
             optflags=''
+            ;;
+        i686)
+            openssltarget='linux-elf'
+            optflags='no-sse2'
+            ;;
+        i486)
+            openssltarget='linux-elf'
+            optflags='386'
             ;;
         arm|armv6h|armv7h)
             openssltarget='linux-armv4'

--- a/pacman-static/PKGBUILD
+++ b/pacman-static/PKGBUILD
@@ -283,7 +283,7 @@ build() {
         -Dbuildstatic=true \
         -Ddefault_library=static \
         -Ddoc=disabled \
-        -Dldcofig=/usr/bin/ldconfig \
+        -Dldconfig=/usr/bin/ldconfig \
         -Dscriptlet-shell=/usr/bin/bash \
         ..
     ninja

--- a/pacman-static/PKGBUILD
+++ b/pacman-static/PKGBUILD
@@ -3,19 +3,19 @@
 # All my PKGBUILDs are managed at https://github.com/eli-schwartz/pkgbuilds
 
 pkgname=pacman-static
-pkgver=6.0.0
-_cares_ver=1.17.1
-_nghttp2_ver=1.43.0
-_curlver=7.77.0
-_sslver=1.1.1k
+pkgver=6.0.1
+_cares_ver=1.17.2
+_nghttp2_ver=1.45.1
+_curlver=7.78.0
+_sslver=1.1.1l
 _zlibver=1.2.11
 _xzver=5.2.5
 _bzipver=1.0.8
 _zstdver=1.5.0
-_libarchive_ver=3.5.1
+_libarchive_ver=3.5.2
 _gpgerrorver=1.42
 _libassuanver=2.5.5
-_gpgmever=1.15.1
+_gpgmever=1.16.0
 pkgrel=1
 pkgdesc="Statically-compiled pacman (to fix or install systems without libc)"
 arch=('i486' 'i686' 'pentium4' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
@@ -62,17 +62,17 @@ source+=("https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${_libassuanver}.tar.
 # gpgme
 source+=("https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-${_gpgmever}.tar.bz2"{,.sig})
 # libarchive
-source+=("https://github.com/libarchive/libarchive/releases/download/${_libarchive_ver}/libarchive-${_libarchive_ver}.tar.xz"{,.asc})
+source+=("https://github.com/libarchive/libarchive/releases/download/v${_libarchive_ver}/libarchive-${_libarchive_ver}.tar.xz"{,.asc})
 validpgpkeys+=('A5A45B12AD92D964B89EEE2DEC560C81CEC2276E') # Martin Matuska <mm@FreeBSD.org>
 
-sha512sums=('78fc5b70a2fc356746f8a4580ce7fd01b25b3463db1b9b008f02a97e22c236fdb1d09985769caf6ac675d9b1091ba0f71afa38ec5759cf7911f1b1a33586f563'
+sha512sums=('d17b9aea9f8d51a5a02fc9faa8e36227c0edea73957cc8a8174a23a81ca42737ecfce630aa86008ab26daec584004b772cd2eb3527aeef9e098b445edaa21f6f'
             'SKIP'
-            'eac69ba356870a1cba420a06771082897be8dd40a68f4e04223f41f3d22626e4f5b3766d3dbcc496dd212be01f64c3ac280a2ebddd31dd88f7350c20f56e5d39'
-            'b11887bcc9274d368088e1a8b6aca62414f20675cf0bc58e948f54fa04c327c39dd23cefe7509eec6397db14b550a3f6b77f5c18b3d735b3eef48ce2da1dcd00'
+            '320a8c9f29b58c55df98be4312d415bc406edbdfb0765aa37570cdb472a84f40c4f95a51c44c5488363c16ad6815c75b5503b32e43d94724c54117ff583c7150'
+            'f625e0ef8508af6475d3e83b51ab29be8a4878e2a87e7f518bea046b76a74bfde7043ca6ec2a9e714c898ab9e5d4a5a678c3347a9f9eb68980438f7ca8ae3fc8'
             'SKIP'
-            'cacd85eb9b2ad90f59595b497035f4660b6c5cff2d653da939c9ceac6dd8dd4bc7bdcb2dfd251862af0c29b9299312bf7271ed0249734fca979c9588799635d6'
+            '3d74343e06dd3d699f4c883758775554956f7f27de470b71f4af0d7f56ff5e4d7c534ab958c8926fae69cd0ded90c173ac3d5a6ad5518d88c2f39f31f8bba2f3'
             'SKIP'
-            '73cd042d4056585e5a9dd7ab68e7c7310a3a4c783eafa07ab0b560e7462b924e4376436a6d38a155c687f6942a881cfc0c1b9394afcde1d8c46bf396e7d51121'
+            'd9611f393e37577cca05004531388d3e0ebbf714894cab9f95f4903909cd4f45c214faab664c0cbc3ad3cca309d500b9e6d0ecbf9a0a0588d1677dc6b047f9e0'
             'SKIP'
             '3857c298663728a465b5f95a3ef44547efbfb420d755e9dde7f20aa3905171b400e1c126d8db5c2b916c733bbd0724d8753cad16c9baf7b12dcd225a3ee04a97'
             '73fd3fff4adeccd4894084c15ddac89890cd10ef105dd5e1835e1e9bbb6a49ff229713bd197d203edfa17c2727700fce65a2a235f07568212d820dca88b528ae'
@@ -87,18 +87,18 @@ sha512sums=('78fc5b70a2fc356746f8a4580ce7fd01b25b3463db1b9b008f02a97e22c236fdb1d
             'SKIP'
             '70117f77aa43bbbe0ed28da5ef23834c026780a74076a92ec775e30f851badb423e9a2cb9e8d142c94e4f6f8a794988c1b788fd4bd2271e562071adf0ab16403'
             'SKIP'
-            '1d75a848cce6389f7cb8896b57a28dfe1dc5a447bfb4f128b0994a43e04134343400a3be063e971f03dfd595474cfd558519741d5d56afb3e84853ad4f2a45c2'
+            '69487be69612e9bf0221ff56ae687248bd13635db1b7087130e93c1670e38f3c810bbca17723555c04fe207976c35871bbc3da005179ce099504321cf33636e4'
             'SKIP'
-            '04ad3e98e840fee19eb4c2652f29eccef1cffc071fd5c6a6feb358fea6048699281c7baacbb9ca8f823b1bfaaef6d4c87d9cf6a8b0c28aab53b75b2d259b2045'
+            'ac7c47f9ddfe5d4d5db6ca9c1bcba788af95662bf0e54ca5426fe66cd8262896e12acc426eecdf0e0d6681c180bcd37f4c4469619273607e95399c7f49b61c7c'
             'SKIP')
-b2sums=('79443cbee5df7b367267c70da04d570455a42d9cfa2e623333fd30e640d3cd9f01da382134efcd1c84202331499fd134b23dde8788a89f6949f0eb40e0e7a38b'
+b2sums=('907c39bb368beea037dcb4b32c56b04a86580123d23ddfe5a1d30ed53143a9b6204044d74040e5bcfe80061673d59597ad2e033525561d6b195a95a104203fa9'
         'SKIP'
-        '0e6c674486c484558a55822501a13ac93c4e890cf62749bc8519690f468912701329b7b9e83b0b68c3f35b72442b1ed47a90050cccd3fc05d79622e1e26634dc'
-        '31dac21ecae231e2a201dc1ba954c1a0663a06f93eb8e7e033ca3c6d385f53e07af0b04854739f1ee8a7f0693f67f620143e152ef092b49342c62279a0480905'
+        '17bc5e0a6270494a0296da7f1394d0b89666ca42ad04bcce097740da2b30cdc575f17e681a8320dc2a2161eeebb753f22f228a340fc7cd690fa883d29149bcd8'
+        'c6f5ad65ca75f8467b624daf3caaee2f35d6e4714ce46ebe1bbf79447feecf8615915b00fa5e7bd1e97c6232864e06c53a792fbadf36a5399883529769273e24'
         'SKIP'
-        'b75e0de2f4134444d62c4495e11045181bb10624c0b48efcfdd45d18749936293b9f1b1f3b59b7c80e997d144a6be266b3cd945a147281a193aa040b6995e6be'
+        '053ec771b15082b153868d70182d61a59ac94553867f153304542ae7e083825c729882044a627016723cd3bbd831f6f3dfe12e12b079da42bc7587e934f04d55'
         'SKIP'
-        'e9bd90f17bc819c4960d07bbee04346e8a7adb87a764a09d033ef76f1d638c67b180c4f2beb84ec25fbff54ccc9c14c13b9b16a27cac231a5dd22b02635d5cec'
+        '9e8739015db63a013c05587e3d164d67c3f65f1f6c5fc75e4592bcd038c036cde88a7bc95fbc1f1b4ed876f6124ca4dabcd4f5dbb45d1b84299f2efe1a59431a'
         'SKIP'
         'e2ff99e8236487f43171c771d0ee89137b73f3d0b2756bcb0d6525c810ffa9f5a3763c3744327fb47cef21eabfc50fff96632f4bbe2cd244206a99daffa0c25a'
         '6bfc4bca5dcadba8a0d4121a2b3ed0bfe440c261003521862c8e6381f1a6f0a72d3fc037351d30afd7ef321e8e8d2ec817c046ac749f2ca0c97fbdc2f7e840b7'
@@ -113,9 +113,9 @@ b2sums=('79443cbee5df7b367267c70da04d570455a42d9cfa2e623333fd30e640d3cd9f01da382
         'SKIP'
         '24952e97c757b97c387ab4c2c4bf7b040f2874e9326c129805c7f5326fa14d80e083b0842e336a635531a2c8d4a66d428c816bae6b175f1c4518add1ffa3554d'
         'SKIP'
-        'd3a6ccaa35360ed3fc79364dfcc3f2fdcb70e5e41ac72ef011373a39d5def9be9ce1be45843ab65a87630d3fc570d29db5f40b9a273aa8e281464c9d1d3477de'
+        'da55e695b148e949a1c0770d0298d7a8c9f87d7a1f9e45d380f8c13c472bd44cb4266adb9a113e2b1dcc2596291744f48fdf998ff2de876059d89d184dc87f3a'
         'SKIP'
-        '0be26a858bffc48bc3dea64e7ea16a703fd7dae1c37dd93e1acde291b6799e323461b3b0bb31c12f63e3429aa4be72d88636606d786978f8d56b94dd2dc144c7'
+        '161ac11115a80c21233e4dbe52f92201fa3372e5750cff38b3f49d60f2440b560c4c9a55dfca8f6313750eb2b65a6b0a8427619c382085bcc24cdfe45f6d6233'
         'SKIP')
 
 export LDFLAGS="$LDFLAGS -static"


### PR DESCRIPTION
- Updates for Archlinux32 (subarchs, OpenSSL build flags)
- Updated to pacman 6.0.1
- Updated 3rdParty libraries
- fixed ldconfig parameter for meson pacman configure