### PR TITLE
`makepkg -si` failed because the directories didn't exist.

### DIFF
--- a/zfs-utils/PKGBUILD
+++ b/zfs-utils/PKGBUILD
@@ -55,13 +55,13 @@ package() {
     install -D -m644 contrib/bash_completion.d/zfs "${pkgdir}"/usr/share/bash-completion/completions/zfs
 
     # Remove uneeded files
-    rm -r "${pkgdir}"/etc/init.d
-    rm -r "${pkgdir}"/etc/sudoers.d #???
+    rm -fr "${pkgdir}"/etc/init.d
+    rm -fr "${pkgdir}"/etc/sudoers.d #???
     # We're experimenting with dracut in [extra], so start installing this.
     #rm -r "${pkgdir}"/usr/lib/dracut
-    rm -r "${pkgdir}"/usr/lib/modules-load.d
-    rm -r "${pkgdir}"/usr/share/initramfs-tools
-    rm -r "${pkgdir}"/usr/share/zfs
+    rm -fr "${pkgdir}"/usr/lib/modules-load.d
+    rm -fr "${pkgdir}"/usr/share/initramfs-tools
+    rm -fr "${pkgdir}"/usr/share/zfs
 
     install -D -m644 "${srcdir}"/zfs.initcpio.hook "${pkgdir}"/usr/lib/initcpio/hooks/zfs
     install -D -m644 "${srcdir}"/zfs.initcpio.install "${pkgdir}"/usr/lib/initcpio/install/zfs


### PR DESCRIPTION
The update from `zfs-utils 2.1.4` failed for me, because it could not build the package. The build process failed trying to remove obsolete files in the `pacakge()` step.
Adding `-f` to `rm` to ignore missing directories fixed it for me.